### PR TITLE
Aktualizace stylů - 1.část

### DIFF
--- a/styles/katastralniuzemi.qml
+++ b/styles/katastralniuzemi.qml
@@ -15,9 +15,9 @@
           <prop k="offset" v="0,0"/>
           <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="0,0,238,255"/>
+          <prop k="outline_color" v="0,0,0,255"/>
           <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.66"/>
+          <prop k="outline_width" v="0.5"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="no"/>
           <data_defined_properties>

--- a/styles/momc.qml
+++ b/styles/momc.qml
@@ -15,9 +15,9 @@
           <prop v="0,0" k="offset"/>
           <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
           <prop v="MM" k="offset_unit"/>
-          <prop v="60,205,3,255" k="outline_color"/>
+          <prop v="102,255,102,255" k="outline_color"/>
           <prop v="solid" k="outline_style"/>
-          <prop v="0.66" k="outline_width"/>
+          <prop v="0.5" k="outline_width"/>
           <prop v="MM" k="outline_width_unit"/>
           <prop v="no" k="style"/>
           <data_defined_properties>

--- a/styles/mop.qml
+++ b/styles/mop.qml
@@ -15,9 +15,9 @@
           <prop v="0,0" k="offset"/>
           <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
           <prop v="MM" k="offset_unit"/>
-          <prop v="166,124,73,255" k="outline_color"/>
+          <prop v="0,206,0,255" k="outline_color"/>
           <prop v="solid" k="outline_style"/>
-          <prop v="0.66" k="outline_width"/>
+          <prop v="0.5" k="outline_width"/>
           <prop v="MM" k="outline_width_unit"/>
           <prop v="no" k="style"/>
           <data_defined_properties>

--- a/styles/obce.qml
+++ b/styles/obce.qml
@@ -17,7 +17,7 @@
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="255,0,0,255"/>
           <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.66"/>
+          <prop k="outline_width" v="0.5"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="no"/>
           <data_defined_properties>

--- a/styles/okresy.qml
+++ b/styles/okresy.qml
@@ -14,9 +14,9 @@
           <prop k="dash_pattern_offset_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="68,184,10,255"/>
+          <prop k="line_color" v="255,0,0,255"/>
           <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.35"/>
+          <prop k="line_width" v="0.4"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
           <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>

--- a/styles/orp.qml
+++ b/styles/orp.qml
@@ -14,9 +14,9 @@
           <prop k="dash_pattern_offset_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="183,118,5,255"/>
+          <prop k="line_color" v="255,128,0,255"/>
           <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.26"/>
+          <prop k="line_width" v="0.4"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
           <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>

--- a/styles/parcely.qml
+++ b/styles/parcely.qml
@@ -17,7 +17,7 @@
           <prop k="offset_unit" v="MM"/>
           <prop k="outline_color" v="0,0,0,255"/>
           <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width" v="0.25"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="no"/>
           <data_defined_properties>

--- a/styles/pou.qml
+++ b/styles/pou.qml
@@ -14,9 +14,9 @@
           <prop k="dash_pattern_offset_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="158,159,148,255"/>
+          <prop k="line_color" v="255,128,0,255"/>
           <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.2"/>
+          <prop k="line_width" v="0.3"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
           <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>

--- a/styles/regionysoudrznosti.qml
+++ b/styles/regionysoudrznosti.qml
@@ -14,9 +14,9 @@
           <prop k="dash_pattern_offset_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="30,165,222,255"/>
+          <prop k="line_color" v="255,128,64,255"/>
           <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.6"/>
+          <prop k="line_width" v="0.7"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
           <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>

--- a/styles/spravniobvody.qml
+++ b/styles/spravniobvody.qml
@@ -15,9 +15,9 @@
           <prop v="0,0" k="offset"/>
           <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
           <prop v="MM" k="offset_unit"/>
-          <prop v="166,124,73,255" k="outline_color"/>
+          <prop v="0,128,0,255" k="outline_color"/>
           <prop v="solid" k="outline_style"/>
-          <prop v="0.66" k="outline_width"/>
+          <prop v="0.5" k="outline_width"/>
           <prop v="MM" k="outline_width_unit"/>
           <prop v="no" k="style"/>
           <data_defined_properties>

--- a/styles/vusc.qml
+++ b/styles/vusc.qml
@@ -14,9 +14,9 @@
           <prop k="dash_pattern_offset_unit" v="MM"/>
           <prop k="draw_inside_polygon" v="0"/>
           <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="36,94,229,255"/>
+          <prop k="line_color" v="255,0,0,255"/>
           <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.5"/>
+          <prop k="line_width" v="0.7"/>
           <prop k="line_width_unit" v="MM"/>
           <prop k="offset" v="0"/>
           <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>

--- a/styles/zsj.qml
+++ b/styles/zsj.qml
@@ -15,9 +15,9 @@
           <prop k="offset" v="0,0"/>
           <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="251,154,153,255"/>
+          <prop k="outline_color" v="0,128,255,255"/>
           <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.66"/>
+          <prop k="outline_width" v="0.5"/>
           <prop k="outline_width_unit" v="MM"/>
           <prop k="style" v="no"/>
           <data_defined_properties>


### PR DESCRIPTION
Změněny styly (barva a tloušťka čáry) u všech vrstev podle zobrazeni v [mapě](https://vdp.cuzk.gov.cz/vdp/ruian/mapa/) kromě:

adresnimista, castiobci, staty, stavebni objekty, ulice

Styly těchto vrstev budou ještě upraveny v další části, na kterou bude vytvořeno nové issue.